### PR TITLE
Allow managing `managedupgrade.appuio.io.ClusterVersion`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,7 +26,7 @@ parameters:
     cluster_version:
       openshiftVersion:
         Major: "4"
-        Minor: "8"
+        Minor: "11"
       spec:
         upstream: https://api.openshift.com/api/upgrades_info/v1/graph
 

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -23,6 +23,13 @@ parameters:
     kustomize_input:
       namespace: ${openshift_upgrade_controller:namespace}
 
+    cluster_version:
+      openshiftVersion:
+        Major: "4"
+        Minor: "8"
+      spec:
+        upstream: https://api.openshift.com/api/upgrades_info/v1/graph
+
     alerts:
       NodeDrainStuck:
         enabled: true

--- a/class/openshift-upgrade-controller.yml
+++ b/class/openshift-upgrade-controller.yml
@@ -7,6 +7,7 @@ parameters:
         output_path: apps/
       - input_paths:
           - ${_base_directory}/component/main.jsonnet
+          - ${_base_directory}/component/cluster-version.jsonnet
         input_type: jsonnet
         output_path: openshift-upgrade-controller/
 

--- a/component/cluster-version.jsonnet
+++ b/component/cluster-version.jsonnet
@@ -1,0 +1,30 @@
+// main template for openshift-upgrade-controller
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.openshift_upgrade_controller;
+
+local cluster_gt_411 =
+  params.cluster_version.openshiftVersion.Major == '4' &&
+  std.parseInt(params.cluster_version.openshiftVersion.Minor) >= 11;
+
+local clusterVersion = kube._Object('managedupgrade.appuio.io/v1beta1', 'ClusterVersion', 'version') {
+  metadata+: {
+    namespace: 'openshift-cluster-version',
+    labels+: {
+      'app.kubernetes.io/managed-by': 'commodore',
+    },
+  },
+  spec: {
+    [if cluster_gt_411 then 'capabilities']: {
+      baselineCapabilitySet: 'v4.11',
+    },
+    channel: 'stable-%(Major)s.%(Minor)s' % params.cluster_version.openshiftVersion,
+  } + com.makeMergeable(params.cluster_version.spec),
+};
+
+{
+  version: clusterVersion,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -46,6 +46,87 @@ The Git reference to the controller deployment manifests.
 The default is the tag of the controller image.
 
 
+== `cluster_version.openshiftVersion`
+
+[horizontal]
+type:: object
+default::
++
+[source,yaml]
+----
+Major: '4'
+Minor: '8'
+----
+
+This parameter is used to conditionally add configurations in the `ClusterVersion` object.
+
+The component currently uses this parameter to set default values for
+* field `capabilities.baselineCapabilitySet`, which was introduced in OpenShift 4.11.
+The component defaults this field to `v4.11`.
+* field `channel`.
+The component sets this field to `stable-<Major>.<Minor>`, where `<Major>` and `<Minor>` are replaced with the values of fields `Major` and `Minor` of this parameter.
+
+== `cluster_version.spec`
+
+[horizontal]
+type:: object
+default::
++
+[source,yaml]
+----
+upstream: https://api.openshift.com/api/upgrades_info/v1/graph
+----
+
+See the https://docs.openshift.com/container-platform/latest/updating/updating-cluster-between-minor.html[OpenShift docs] for available parameters and values.
+
+[NOTE]
+====
+Field `clusterID` must be set in the `ClusterVersion` object.
+The value for this field is supposed to be extracted from the cluster as a fact.
+However, the corresponding dynamic fact isn't implemented yet.
+We recommend that users set `spec.clusterID` to a non-component parameter such as `openshift.clusterID` in the config hierarchy.
+====
+
+Values specified in this parameter take precedence over default values derived from parameter `openshiftVersion`.
+
+
+=== Example
+
+We recommend configuring a reference for component parameter `openshift_upgrade_controller.cluster_version.spec.clusterID` for all OpenShift 4 clusters:
+
+.openshift4.yml
+[source,yaml]
+----
+parameters:
+  openshift:
+    clusterID: 'OVERRIDE_THIS_IN_THE_CLUSTER_CONFIG'
+  openshift_upgrade_controller:
+    cluster_version:
+      spec:
+        clusterID: ${openshift.clusterID}
+----
+
+With this approach, each individual cluster config only needs to set generic parameter `openshift.clusterID`.
+
+.cluster.yml
+[source,yaml]
+----
+parameters:
+  openshift:
+    clusterID: '6d8329e3-7098-4bab-b7d8-11f1dc353481'
+
+  openshift_upgrade_controller:
+    cluster_version:
+      spec: ...
+----
+
+[NOTE]
+====
+This example assumes that `openshift_upgrade_controller.cluster_version.spec.clusterID` is set to `${openshift.clusterID}` somewhere in the inventory.
+Due to https://github.com/projectsyn/commodore/issues/138, this can not yet be done in the defaults.
+====
+
+
 == `alerts`
 
 [horizontal]

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/version.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/version.yaml
@@ -1,0 +1,12 @@
+apiVersion: managedupgrade.appuio.io/v1beta1
+kind: ClusterVersion
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    name: version
+  name: version
+  namespace: openshift-cluster-version
+spec:
+  channel: stable-4.8
+  upstream: https://api.openshift.com/api/upgrades_info/v1/graph

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/version.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/version.yaml
@@ -8,5 +8,7 @@ metadata:
   name: version
   namespace: openshift-cluster-version
 spec:
-  channel: stable-4.8
+  capabilities:
+    baselineCapabilitySet: v4.11
+  channel: stable-4.11
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph


### PR DESCRIPTION
Almost directly lifted from https://github.com/appuio/component-openshift4-version.
Should keep it compatible for easy migrations.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
