### PR TITLE
Aggregate permissions for upgrade controller custom resources to `view` and `edit` cluster roles

### DIFF
--- a/class/openshift-upgrade-controller.yml
+++ b/class/openshift-upgrade-controller.yml
@@ -8,6 +8,7 @@ parameters:
       - input_paths:
           - ${_base_directory}/component/main.jsonnet
           - ${_base_directory}/component/cluster-version.jsonnet
+          - ${_base_directory}/component/rbac.jsonnet
         input_type: jsonnet
         output_path: openshift-upgrade-controller/
 

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -1,0 +1,57 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local aggregatedRoles = [
+  kube.ClusterRole('syn:openshift-upgrade-controller:view') {
+    metadata+: {
+      labels+: {
+        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+      },
+    },
+    rules: [
+      {
+        apiGroups: 'managedupgrade.appuio.io',
+        resources: [
+          'clusterversions',
+          'upgradeconfigs',
+          'upgradejobs',
+        ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+    ],
+  },
+  kube.ClusterRole('syn:openshift-upgrade-controller:edit') {
+    metadata+: {
+      labels+: {
+        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+      },
+    },
+    rules: [
+      {
+        apiGroups: 'managedupgrade.appuio.io',
+        resources: [
+          'clusterversions',
+          'upgradeconfigs',
+          'upgradejobs',
+        ],
+        verbs: [
+          'create',
+          'delete',
+          'deletecollection',
+          'patch',
+          'update',
+        ],
+      },
+    ],
+  },
+];
+
+{
+  '30_rbac': aggregatedRoles,
+}

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/30_rbac.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/30_rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift-upgrade-controller-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn:openshift-upgrade-controller:view
+rules:
+  - apiGroups: managedupgrade.appuio.io
+    resources:
+      - clusterversions
+      - upgradeconfigs
+      - upgradejobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift-upgrade-controller-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn:openshift-upgrade-controller:edit
+rules:
+  - apiGroups: managedupgrade.appuio.io
+    resources:
+      - clusterversions
+      - upgradeconfigs
+      - upgradejobs
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update


### PR DESCRIPTION
Without this, it's quite annoying to look at the state of unattended upgrades.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
