### PR TITLE
Adjust silence script to pass comment into jq as an argument

### DIFF
--- a/component/scripts/silence.sh
+++ b/component/scripts/silence.sh
@@ -25,7 +25,7 @@ while IFS= read -r silence; do
       '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy | .comment = $comment'
   )
 
-  id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
+  id=$(curl "${curl_opts[@]}" | jq --arg comment "${comment}" -r '.[] | select(.status.state == "active") | select(.comment == "$comment") | .id' | head -n 1)
   if [ -n "${id}" ]; then
     body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
   fi

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/90_upgrade_silence.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/90_upgrade_silence.yaml
@@ -55,7 +55,7 @@ data:
           '.startsAt = $startsAt | .endsAt = $endsAt | .createdBy = $createdBy | .comment = $comment'
       )
 
-      id=$(curl "${curl_opts[@]}" | jq -r ".[] | select(.status.state == \"active\") | select(.comment == \"${comment}\") | .id" | head -n 1)
+      id=$(curl "${curl_opts[@]}" | jq --arg comment "${comment}" -r '.[] | select(.status.state == "active") | select(.comment == "$comment") | .id' | head -n 1)
       if [ -n "${id}" ]; then
         body=$(printf %s "${body}" | jq --arg id "${id}" '.id = $id')
       fi


### PR DESCRIPTION
This avoids quoting errors from using shell variable substitution in the jq script.

The previous version of the script failed with

```
jq: error: syntax error, unexpected IDENT, expecting ';' or ')' (Unix shell quoting issues?) at <top-level>, line 1:
.[] | select(.status.state == "active") | select(.comment == "Maintenance silence 'Ingress SLO does not cope with some networking changes' from '"tuesday-evening-4-11-43-1688500800"'") | .id
jq: 1 compile error
```




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
