### PR TITLE
Remove default `baselineCapabilitySet` config

### DIFF
--- a/component/cluster-version.jsonnet
+++ b/component/cluster-version.jsonnet
@@ -6,10 +6,6 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift_upgrade_controller;
 
-local cluster_gt_411 =
-  params.cluster_version.openshiftVersion.Major == '4' &&
-  std.parseInt(params.cluster_version.openshiftVersion.Minor) >= 11;
-
 local clusterVersion = kube._Object('managedupgrade.appuio.io/v1beta1', 'ClusterVersion', 'version') {
   metadata+: {
     namespace: params.namespace,
@@ -20,9 +16,6 @@ local clusterVersion = kube._Object('managedupgrade.appuio.io/v1beta1', 'Cluster
   spec: {
     template: {
       spec: {
-        [if cluster_gt_411 then 'capabilities']: {
-          baselineCapabilitySet: 'v4.11',
-        },
         channel: 'stable-%(Major)s.%(Minor)s' % params.cluster_version.openshiftVersion,
       } + com.makeMergeable(params.cluster_version.spec) + {
         // desiredUpdate is removed by the openshift-upgrade-controller, but this might help causing less confusion

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -240,8 +240,6 @@ Minor: '8'
 This parameter is used to conditionally add configurations in the `ClusterVersion` object.
 
 The component currently uses this parameter to set default values for
-* field `capabilities.baselineCapabilitySet`, which was introduced in OpenShift 4.11.
-The component defaults this field to `v4.11`.
 * field `channel`.
 The component sets this field to `stable-<Major>.<Minor>`, where `<Major>` and `<Minor>` are replaced with the values of fields `Major` and `Minor` of this parameter.
 

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/version.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/version.yaml
@@ -10,8 +10,6 @@ metadata:
 spec:
   template:
     spec:
-      capabilities:
-        baselineCapabilitySet: v4.11
       channel: stable-4.11
       clusterID: 5cc27d6c-569f-430c-a74a-cf0d9aebf348
       upstream: https://api.openshift.com/api/upgrades_info/v1/graph


### PR DESCRIPTION
We've researched the currently available capabilities and have come to the conclusion that there's no benefit in setting a `baselineCapabilitySet` through the component.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
