### PR TITLE
Tune NodeDrainStuck alert

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -68,7 +68,7 @@ parameters:
             summary: Node is draining for more than 10 minutes.
           expr: |
             openshift_upgrade_controller_node_draining == 1
-          for: 10m
+          for: 15m
           labels:
             severity: warning
             Maintenance: "true"

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
@@ -31,7 +31,7 @@ spec:
             summary: Node is draining for more than 10 minutes.
           expr: |
             openshift_upgrade_controller_node_draining == 1
-          for: 10m
+          for: 15m
           labels:
             Maintenance: 'true'
             severity: warning


### PR DESCRIPTION
Slightly increase the duration of the NodeDrainStuck alert to allow enough time for the workaround to fix stuck loki ingester pods.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
