### PR TITLE
Add alert for paused machineconfigpools

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -103,3 +103,17 @@ parameters:
           labels:
             severity: info
             Maintenance: "true"
+      PausedMachineConfigPool:
+        enabled: true
+        rule:
+          annotations:
+            description: |
+              MachineConfigPool {{$labels.pool}} is paused. Paused machine config pools have the potential to make the next upgradejob fail.
+            message: MachineConfigPool {{$labels.pool}} is paused
+            summary: Paused MachineConfigPool
+          expr: |
+            openshift_upgrade_controller_machine_config_pools_paused > 0
+          for: 5m
+          labels:
+            severity: warning
+            Maintenance: "false"

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -108,12 +108,12 @@ parameters:
         rule:
           annotations:
             description: |
-              MachineConfigPool {{$labels.pool}} is paused. Paused machine config pools have the potential to make the next upgradejob fail.
-            message: MachineConfigPool {{$labels.pool}} is paused
+              MachineConfigPool {{$labels.pool}} is paused. A paused MachineConfigPool will likely block the next maintenance.
+            message: MachineConfigPool {{$labels.pool}} is paused.
             summary: Paused MachineConfigPool
+            runbook_url: https://hub.syn.tools/openshift-upgrade-controller/runbooks/PausedMachineConfigPool.html
           expr: |
-            openshift_upgrade_controller_machine_config_pools_paused > 0
-          for: 5m
+            group(openshift_upgrade_controller_machine_config_pools_paused > 0) by (pool) unless on() group(openshift_upgrade_controller_upgradejob_state{state=~"active|paused"})
+          for: 2h
           labels:
             severity: warning
-            Maintenance: "false"

--- a/docs/modules/ROOT/pages/runbooks/PausedMachineConfigPool.adoc
+++ b/docs/modules/ROOT/pages/runbooks/PausedMachineConfigPool.adoc
@@ -1,0 +1,31 @@
+= PausedMachineConfigPool
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires when a MachineConfigPool is paused, but there are no active or paused upgradejobs.
+Paused machine config pools will likely block the next maintenance and prevent the upgradejob from progressing.
+
+
+== icon:bug[] Steps for debugging
+
+Possible reasons why a MachineConfigPool is paused:
+
+* (likely) An engineer manually paused the MachineConfigPool (e.g. to prevent node reboots)
+* Something went wrong during a delayed upgrade of a MachineConfigPool by the upgrade controller
+* Another operator/component on the cluster paused the MachineConfigPool
+
+=== icon:search[] Check last update to the `.spec.paused` field
+
+You may be able to figure out who paused the pool by looking at the managed fields:
+
+[source,shell]
+----
+kubectl get mcp -oyaml --show-managed-fields | yq '.items[] | select(.spec.paused) | .metadata | {.name: .managedFields[] | select(.fieldsV1."f:spec"."f:paused")}'
+----
+
+If the manager of the field is `kubectl-edit` or `kubectl-patch` and it was recently updated, it was likely done manually by an engineer.
+Depending on the reason for pausing, consider to either ensure it is unpaused before the next maintenance or suspending maintenance on the cluster.
+
+If the pool was paused by an operator, look for the reason in the operator logs.

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
@@ -37,3 +37,17 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: openshift-upgrade-controller
+        - alert: PausedMachineConfigPool
+          annotations:
+            description: |
+              MachineConfigPool {{$labels.pool}} is paused. Paused machine config pools have the potential to make the next upgradejob fail.
+            message: MachineConfigPool {{$labels.pool}} is paused
+            summary: Paused MachineConfigPool
+          expr: |
+            openshift_upgrade_controller_machine_config_pools_paused > 0
+          for: 5m
+          labels:
+            Maintenance: 'false'
+            severity: warning
+            syn: 'true'
+            syn_component: openshift-upgrade-controller

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
@@ -40,14 +40,14 @@ spec:
         - alert: PausedMachineConfigPool
           annotations:
             description: |
-              MachineConfigPool {{$labels.pool}} is paused. Paused machine config pools have the potential to make the next upgradejob fail.
-            message: MachineConfigPool {{$labels.pool}} is paused
+              MachineConfigPool {{$labels.pool}} is paused. A paused MachineConfigPool will likely block the next maintenance.
+            message: MachineConfigPool {{$labels.pool}} is paused.
+            runbook_url: https://hub.syn.tools/openshift-upgrade-controller/runbooks/PausedMachineConfigPool.html
             summary: Paused MachineConfigPool
           expr: |
-            openshift_upgrade_controller_machine_config_pools_paused > 0
-          for: 5m
+            group(openshift_upgrade_controller_machine_config_pools_paused > 0) by (pool) unless on() group(openshift_upgrade_controller_upgradejob_state{state=~"active|paused"})
+          for: 2h
           labels:
-            Maintenance: 'false'
             severity: warning
             syn: 'true'
             syn_component: openshift-upgrade-controller


### PR DESCRIPTION

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
