### PR TITLE
OpenShift 4.17 requires `CREATE alertmanagers/api` for creating silences

### DIFF
--- a/component/silence.libsonnet
+++ b/component/silence.libsonnet
@@ -28,6 +28,8 @@ local cr = kube.ClusterRole('maintenance-silence-alertmanager-api') + namespace 
         'alertmanagers/api',
       ],
       verbs: [
+        // OpenShift 4.17 alertmanager kube-rbac-proxy checks for `create` verb
+        'create',
         'get',
       ],
     },


### PR DESCRIPTION
Otherwise the start hook silently fails with

```
Forbidden (user=system:serviceaccount:appuio-openshift-upgrade-controller:maintenance-silence, verb=create, resource=alertmanagers, subresource=api)
```


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
