### PR TITLE
Add `nodeforcedrains` and `upgradesuspensionwindows` to aggregated RBAC

### DIFF
--- a/component/admin-ack.libsonnet
+++ b/component/admin-ack.libsonnet
@@ -5,6 +5,8 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift_upgrade_controller;
 
+local api = import 'api.libsonnet';
+
 local enabled =
   std.length(params.admin_ack.upgrade_job_selector) > 0;
 
@@ -41,7 +43,7 @@ local cm = kube.ConfigMap(manifestName) + namespace {
   },
 };
 
-local ujh = kube._Object('managedupgrade.appuio.io/v1beta1', 'UpgradeJobHook', manifestName) + namespace {
+local ujh = kube._Object(api.apiVersion, 'UpgradeJobHook', manifestName) + namespace {
   spec+: {
     selector: params.admin_ack.upgrade_job_selector,
     events: [

--- a/component/api.libsonnet
+++ b/component/api.libsonnet
@@ -1,0 +1,4 @@
+{
+  apiGroup: 'managedupgrade.appuio.io',
+  apiVersion: '%s/v1beta1' % self.apiGroup,
+}

--- a/component/cluster-version.jsonnet
+++ b/component/cluster-version.jsonnet
@@ -6,7 +6,9 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift_upgrade_controller;
 
-local clusterVersion = kube._Object('managedupgrade.appuio.io/v1beta1', 'ClusterVersion', 'version') {
+local api = import 'api.libsonnet';
+
+local clusterVersion = kube._Object(api.apiVersion, 'ClusterVersion', 'version') {
   metadata+: {
     namespace: params.namespace,
     labels+: {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -6,6 +6,8 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift_upgrade_controller;
 
+local api = import 'api.libsonnet';
+
 local alertlabels = {
   syn: 'true',
   syn_component: 'openshift-upgrade-controller',
@@ -33,7 +35,7 @@ local alerts = function(name, groupName, alerts)
 
 local upgradeConfigs = com.generateResources(
   params.upgrade_configs,
-  function(name) kube._Object('managedupgrade.appuio.io/v1beta1', 'UpgradeConfig', name) {
+  function(name) kube._Object(api.apiVersion, 'UpgradeConfig', name) {
     metadata+: {
       namespace: params.namespace,
     },
@@ -42,7 +44,7 @@ local upgradeConfigs = com.generateResources(
 
 local upgradeJobHooks = com.generateResources(
   params.upgrade_job_hooks,
-  function(name) kube._Object('managedupgrade.appuio.io/v1beta1', 'UpgradeJobHook', name) {
+  function(name) kube._Object(api.apiVersion, 'UpgradeJobHook', name) {
     metadata+: {
       namespace: params.namespace,
     },
@@ -62,7 +64,7 @@ local upgradeJobHooks = com.generateResources(
 
 local upgradeSuspensionWindows = com.generateResources(
   params.upgrade_suspension_windows,
-  function(name) kube._Object('managedupgrade.appuio.io/v1beta1', 'UpgradeSuspensionWindow', name) {
+  function(name) kube._Object(api.apiVersion, 'UpgradeSuspensionWindow', name) {
     metadata+: {
       namespace: params.namespace,
     },
@@ -71,7 +73,7 @@ local upgradeSuspensionWindows = com.generateResources(
 
 local nodeForceDrains = com.generateResources(
   params.node_force_drains,
-  function(name) kube._Object('managedupgrade.appuio.io/v1beta1', 'NodeForceDrain', name) {
+  function(name) kube._Object(api.apiVersion, 'NodeForceDrain', name) {
     metadata+: {
       namespace: params.namespace,
     },

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -16,9 +16,11 @@ local aggregatedRoles = [
         apiGroups: [ api.apiGroup ],
         resources: [
           'clusterversions',
+          'nodeforcedrains',
           'upgradeconfigs',
           'upgradejobs',
           'upgradejobhooks',
+          'upgradesuspensionwindows',
         ],
         verbs: [
           'get',
@@ -40,9 +42,11 @@ local aggregatedRoles = [
         apiGroups: [ api.apiGroup ],
         resources: [
           'clusterversions',
+          'nodeforcedrains',
           'upgradeconfigs',
           'upgradejobs',
           'upgradejobhooks',
+          'upgradesuspensionwindows',
         ],
         verbs: [
           'create',

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -1,5 +1,7 @@
 local kube = import 'kube-ssa-compat.libsonnet';
 
+local api = import 'api.libsonnet';
+
 local aggregatedRoles = [
   kube.ClusterRole('syn:openshift-upgrade-controller:view') {
     metadata+: {
@@ -11,7 +13,7 @@ local aggregatedRoles = [
     },
     rules: [
       {
-        apiGroups: [ 'managedupgrade.appuio.io' ],
+        apiGroups: [ api.apiGroup ],
         resources: [
           'clusterversions',
           'upgradeconfigs',
@@ -35,7 +37,7 @@ local aggregatedRoles = [
     },
     rules: [
       {
-        apiGroups: [ 'managedupgrade.appuio.io' ],
+        apiGroups: [ api.apiGroup ],
         resources: [
           'clusterversions',
           'upgradeconfigs',

--- a/component/silence.libsonnet
+++ b/component/silence.libsonnet
@@ -5,6 +5,8 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift_upgrade_controller;
 
+local api = import 'api.libsonnet';
+
 local enabled =
   std.length(params.upgrade_silence.upgrade_job_selector) > 0 &&
   std.length(params.upgrade_silence.alert_matchers) > 0;
@@ -91,7 +93,7 @@ local events = if params.upgrade_silence.handle_delayed_worker_pools then [
   'Finish',
 ];
 
-local ujh = kube._Object('managedupgrade.appuio.io/v1beta1', 'UpgradeJobHook', 'maintenance-silence') + namespace {
+local ujh = kube._Object(api.apiVersion, 'UpgradeJobHook', 'maintenance-silence') + namespace {
   spec+: {
     selector: params.upgrade_silence.upgrade_job_selector,
     events: events,

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/30_rbac.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/30_rbac.yaml
@@ -12,9 +12,11 @@ rules:
       - managedupgrade.appuio.io
     resources:
       - clusterversions
+      - nodeforcedrains
       - upgradeconfigs
       - upgradejobs
       - upgradejobhooks
+      - upgradesuspensionwindows
     verbs:
       - get
       - list
@@ -33,9 +35,11 @@ rules:
       - managedupgrade.appuio.io
     resources:
       - clusterversions
+      - nodeforcedrains
       - upgradeconfigs
       - upgradejobs
       - upgradejobhooks
+      - upgradesuspensionwindows
     verbs:
       - create
       - delete

--- a/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/30_rbac.yaml
+++ b/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/30_rbac.yaml
@@ -12,9 +12,11 @@ rules:
       - managedupgrade.appuio.io
     resources:
       - clusterversions
+      - nodeforcedrains
       - upgradeconfigs
       - upgradejobs
       - upgradejobhooks
+      - upgradesuspensionwindows
     verbs:
       - get
       - list
@@ -33,9 +35,11 @@ rules:
       - managedupgrade.appuio.io
     resources:
       - clusterversions
+      - nodeforcedrains
       - upgradeconfigs
       - upgradejobs
       - upgradejobhooks
+      - upgradesuspensionwindows
     verbs:
       - create
       - delete


### PR DESCRIPTION
Additionally, this PR introduces a helper Jsonnet library which defines the upgrade controller's CRD API group and `apiVersion`.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
