### PR TITLE
Draft: Dynamically generate PDB alerts

### DIFF
--- a/class/openshift-upgrade-controller.yml
+++ b/class/openshift-upgrade-controller.yml
@@ -9,6 +9,7 @@ parameters:
           - ${_base_directory}/component/main.jsonnet
           - ${_base_directory}/component/cluster-version.jsonnet
           - ${_base_directory}/component/rbac.jsonnet
+          - ${_base_directory}/component/dynamic-pdb-alerts.jsonnet
         input_type: jsonnet
         output_path: openshift-upgrade-controller/
 

--- a/component/dynamic-pdb-alerts.jsonnet
+++ b/component/dynamic-pdb-alerts.jsonnet
@@ -1,0 +1,108 @@
+local kube = import 'kube-ssa-compat.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+
+local api = import 'api.libsonnet';
+local esp = import 'lib/espejote.libsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift_upgrade_controller;
+
+local name = 'dynamic-pdb-alerts';
+local sa = kube.ServiceAccount(name) {
+  metadata+: {
+    namespace: params.namespace,
+  },
+};
+
+local role = kube.Role(name) {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  rules: [
+    {
+      apiGroups: [ 'monitoring.coreos.com' ],
+      resources: [ 'prometheusrules' ],
+      verbs: [ 'get', 'list', 'watch', 'create', 'delete', 'patch' ],
+    },
+    {
+      apiGroups: [ api.apiGroup ],
+      resources: [ 'nodeforcedrains' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+local rolebinding = kube.RoleBinding(name) {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  subjects_: [ sa ],
+  roleRef_: role,
+};
+
+local mr = esp.managedResource(name, params.namespace) {
+  spec+: {
+    serviceAccountRef: {
+      name: sa.metadata.name,
+    },
+    context: [
+      {
+        name: 'prometheusrules',
+        resource: {
+          apiVersion: 'monitoring.coreos.com/v1',
+          kind: 'PrometheusRule',
+        },
+      },
+      {
+        name: 'nodeforcedrains',
+        resource: {
+          apiVersion: api.apiVersion,
+          kind: 'NodeForceDrain',
+        },
+      },
+      {
+        name: 'namespaces',
+        resource: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+        },
+      },
+    ],
+    triggers: [
+      {
+        name: 'prometheusrule',
+        watchContextResource: {
+          name: 'prometheusrules',
+        },
+      },
+      {
+        name: 'nodeforcedrain',
+        watchContextResource: {
+          name: 'nodeforcedrains',
+        },
+      },
+      {
+        name: 'namespaces',
+        watchContextResource: {
+          name: 'namespaces',
+        },
+      },
+    ],
+    template: importstr 'espejote-templates/dynamic-pdb-alerts.jsonnet',
+  },
+};
+
+if std.member(inv.applications, 'espejote') then
+  {
+    '40_pdb_alerts_managedresource': mr,
+    '40_pdb_alerts_rbac': [
+      sa,
+      role,
+      rolebinding,
+    ],
+  }
+else
+  std.trace(
+    'Unable to deploy dynamic PDB alert: Espejote not present on target cluster',
+    {}
+  )

--- a/component/espejote-templates/dynamic-pdb-alerts.jsonnet
+++ b/component/espejote-templates/dynamic-pdb-alerts.jsonnet
@@ -1,0 +1,69 @@
+local esp = import 'espejote.libsonnet';
+
+local nodeforcedrains = esp.context().nodeforcedrains;
+
+local nfd_ns_selectors = [
+  std.get(nfd.spec, 'namespaceSelector', {})
+  for nfd in nodeforcedrains
+];
+
+local syn_namespaces = [
+  ns.metadata.name
+  for ns in esp.context().namespaces
+  if std.get(ns.metadata.labels, 'openshift.io/cluster-monitoring', 'false') == 'true'
+];
+
+local include_ns_sel = 'namespace=~"(%s)"' % std.join('|', syn_namespaces);
+
+local makePdbRules(limitNamespaces) =
+  local ns_sel = if limitNamespaces then
+    include_ns_sel
+  else
+    '';
+  {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'PrometheusRule',
+    metadata: {
+      name: 'dynamic-pdb-alerts',
+      annotations: {
+        'espejote.io/ignore': 'openshift4-monitoring-rules',
+      },
+    },
+    spec: {
+      groups: [
+        {
+          name: 'pdb.alerts',
+          rules: [
+            {
+              alert: 'PodDisruptionBudgetAtLimit',
+              expr: |||
+                max by (namespace, poddisruptionbudget) (
+                  kube_poddisruptionbudget_status_current_healthy{%(ns_sel)s} == kube_poddisruptionbudget_status_desired_healthy{%(ns_sel)s}
+                  and on (namespace, poddisruptionbudget)
+                  kube_poddisruptionbudget_status_expected_pods{%(ns_sel)s} > 0
+                )
+              ||| % { ns_sel: ns_sel },
+              labels: {
+                syn: 'true',
+                severity: 'critical',
+              },
+            },
+            {
+              alert: 'PodDisruptionBudgetLimit',
+              expr: |||
+                max by(namespace, poddisruptionbudget) (
+                  kube_poddisruptionbudget_status_current_healthy{%(ns_sel)s} < kube_poddisruptionbudget_status_desired_healthy{%(ns_sel)s}
+                )
+              ||| % { ns_sel: ns_sel },
+              labels: {
+                syn: 'true',
+                severity: 'warning',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+makePdbRules(std.length(nodeforcedrains) > 0)

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,4 +1,13 @@
+applications:
+  - espejote
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
   openshift_upgrade_controller:
     cluster_version:
       spec:

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/40_pdb_alerts_managedresource.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/40_pdb_alerts_managedresource.yaml
@@ -1,0 +1,103 @@
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: dynamic-pdb-alerts
+  name: dynamic-pdb-alerts
+  namespace: appuio-openshift-upgrade-controller
+spec:
+  context:
+    - name: prometheusrules
+      resource:
+        apiVersion: monitoring.coreos.com/v1
+        kind: PrometheusRule
+    - name: nodeforcedrains
+      resource:
+        apiVersion: managedupgrade.appuio.io/v1beta1
+        kind: NodeForceDrain
+    - name: namespaces
+      resource:
+        apiVersion: v1
+        kind: Namespace
+  serviceAccountRef:
+    name: dynamic-pdb-alerts
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local nodeforcedrains = esp.context().nodeforcedrains;
+
+    local nfd_ns_selectors = [
+      std.get(nfd.spec, 'namespaceSelector', {})
+      for nfd in nodeforcedrains
+    ];
+
+    local syn_namespaces = [
+      ns.metadata.name
+      for ns in esp.context().namespaces
+      if std.get(ns.metadata.labels, 'openshift.io/cluster-monitoring', 'false') == 'true'
+    ];
+
+    local include_ns_sel = 'namespace=~"(%s)"' % std.join('|', syn_namespaces);
+
+    local makePdbRules(limitNamespaces) =
+      local ns_sel = if limitNamespaces then
+        include_ns_sel
+      else
+        '';
+      {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'PrometheusRule',
+        metadata: {
+          name: 'dynamic-pdb-alerts',
+          annotations: {
+            'espejote.io/ignore': 'openshift4-monitoring-rules',
+          },
+        },
+        spec: {
+          groups: [
+            {
+              name: 'pdb.alerts',
+              rules: [
+                {
+                  alert: 'PodDisruptionBudgetAtLimit',
+                  expr: |||
+                    max by (namespace, poddisruptionbudget) (
+                      kube_poddisruptionbudget_status_current_healthy{%(ns_sel)s} == kube_poddisruptionbudget_status_desired_healthy{%(ns_sel)s}
+                      and on (namespace, poddisruptionbudget)
+                      kube_poddisruptionbudget_status_expected_pods{%(ns_sel)s} > 0
+                    )
+                  ||| % { ns_sel: ns_sel },
+                  labels: {
+                    syn: 'true',
+                    severity: 'critical',
+                  },
+                },
+                {
+                  alert: 'PodDisruptionBudgetLimit',
+                  expr: |||
+                    max by(namespace, poddisruptionbudget) (
+                      kube_poddisruptionbudget_status_current_healthy{%(ns_sel)s} < kube_poddisruptionbudget_status_desired_healthy{%(ns_sel)s}
+                    )
+                  ||| % { ns_sel: ns_sel },
+                  labels: {
+                    syn: 'true',
+                    severity: 'warning',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+    makePdbRules(std.length(nodeforcedrains) > 0)
+  triggers:
+    - name: prometheusrule
+      watchContextResource:
+        name: prometheusrules
+    - name: nodeforcedrain
+      watchContextResource:
+        name: nodeforcedrains
+    - name: namespaces
+      watchContextResource:
+        name: namespaces

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/40_pdb_alerts_rbac.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/40_pdb_alerts_rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: dynamic-pdb-alerts
+  name: dynamic-pdb-alerts
+  namespace: appuio-openshift-upgrade-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    name: dynamic-pdb-alerts
+  name: dynamic-pdb-alerts
+  namespace: appuio-openshift-upgrade-controller
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+  - apiGroups:
+      - managedupgrade.appuio.io
+    resources:
+      - nodeforcedrains
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    name: dynamic-pdb-alerts
+  name: dynamic-pdb-alerts
+  namespace: appuio-openshift-upgrade-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dynamic-pdb-alerts
+subjects:
+  - kind: ServiceAccount
+    name: dynamic-pdb-alerts
+    namespace: appuio-openshift-upgrade-controller


### PR DESCRIPTION
Initial draft simply generates alerts with restricted namespace selector (only namespaces which have annotation
`openshift.io/cluster-monitoring=true`) if there are any `NodeForceDrain` resources deployed on the cluster.

Note that this can be incorrect, if the `NodeForceDrain` resources have specific namespace selectors. Additionally, even a smarter version can be incorrect if the `NodeForceDrain` has JQ pod selector expressions.




## Checklist

- [ ] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [ ] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
