### PR TITLE
Properly trim quoted target version in admin-ack script

### DIFF
--- a/component/scripts/admin-ack.sh
+++ b/component/scripts/admin-ack.sh
@@ -8,7 +8,7 @@ if [ -z "${version}" ]; then
   exit 0
 fi
 
-majorMinor=$(printf "%s" "$version" | cut -d "." -f 1,2)
+majorMinor=$(printf "%s" "$version"  | tr -d '"' | cut -d "." -f 1,2)
 
 ackKey=$(printf "%s" "$OVERRIDES_JSON" | jq -r --arg majorMinor "$majorMinor" '.[$majorMinor] // ""')
 

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/90_admin_ack.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/90_admin_ack.yaml
@@ -36,7 +36,7 @@ data:
       exit 0
     fi
 
-    majorMinor=$(printf "%s" "$version" | cut -d "." -f 1,2)
+    majorMinor=$(printf "%s" "$version"  | tr -d '"' | cut -d "." -f 1,2)
 
     ackKey=$(printf "%s" "$OVERRIDES_JSON" | jq -r --arg majorMinor "$majorMinor" '.[$majorMinor] // ""')
 


### PR DESCRIPTION
Otherwise, the extracted minor version is left with a leading double quote when it's fed to `jq`.

Example output for 4.20 without the fix:

```
+ version='"4.20.14"'
+ '[' -z '"4.20.14"' ']'
++ printf %s '"4.20.14"'
++ cut -d . -f 1,2
+ majorMinor='"4.20' ##<< NOTE HERE
++ printf %s '{"4.19":"ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20","4.20":"ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20"}'
++ jq -r --arg majorMinor '"4.20' '.[$majorMinor] // ""'
+ ackKey=
```

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
