### PR TITLE
Deploy dedicated RBAC (serviceaccount & clusterrolebinding) for hooks

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -42,6 +42,23 @@ local upgradeConfigs = com.generateResources(
   },
 );
 
+local upgradeJobHookSA = kube.ServiceAccount('hook-manager') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+};
+
+local upgradeJobHookCRB =
+  kube.ClusterRoleBinding('openshift-upgrade-controller:hook-manager:cluster-admin')
+  {
+    roleRef: {
+      apiVersion: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'cluster-admin',
+    },
+    subjects_: [ upgradeJobHookSA ],
+  };
+
 local upgradeJobHooks = com.generateResources(
   params.upgrade_job_hooks,
   function(name) kube._Object(api.apiVersion, 'UpgradeJobHook', name) {
@@ -53,6 +70,7 @@ local upgradeJobHooks = com.generateResources(
         spec+: {
           template+: {
             spec+: {
+              serviceAccountName: upgradeJobHookSA.metadata.name,
               priorityClassName: 'system-cluster-critical',
             },
           },
@@ -82,6 +100,7 @@ local nodeForceDrains = com.generateResources(
 
 {
   '10_prometheusrule': alerts('openshift-upgrade-controller', 'drain.alerts', params.alerts),
+  '15_upgradejobhook_rbac': [ upgradeJobHookSA, upgradeJobHookCRB ],
   '20_upgradeconfigs': upgradeConfigs,
   '22_upgradejobhooks': upgradeJobHooks,
   '24_upgradesuspensionwindows': upgradeSuspensionWindows,

--- a/docs/modules/ROOT/pages/how-tos/upgradejobhooks.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgradejobhooks.adoc
@@ -7,7 +7,6 @@ This is a collection of upgradejobhooks for frequently used one-off tasks.
 Scale down a machineset to remove a node after upgradejob is finished.
 Disables ArgoCD auto-sync for the `root` and `openshift4-nodes` apps.
 Only runs once on the next UpgradeJob due to the `.spec.run: Next` setting.
-A clusterrolebinding for cluster-admin for the appuio-openshift-upgrade-controller default serviceaccount is included below.
 
 [source,yaml]
 ----
@@ -51,22 +50,10 @@ spec:
                   name: export
               workingDir: /export
           restartPolicy: Never
+          serviceAccountName: hook-manager
           volumes:
             - emptyDir: {}
               name: export
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: drain-nodes-upgrade-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: appuio-openshift-upgrade-controller
 ----
 
 
@@ -77,7 +64,6 @@ Only works on clusters that use machinesets.
 This is useful for example when cloudscale requests to power off certain VMs completely for cold migration.
 With this upgradejobhook we instead simply replace all the affected nodes.
 Only runs once on the next UpgradeJob due to the `.spec.run: Next` setting.
-A clusterrolebinding for cluster-admin for the appuio-openshift-upgrade-controller default serviceaccount is included below.
 
 [source,yaml]
 ----
@@ -114,19 +100,7 @@ spec:
               image: quay.io/appuio/oc:v4.20
               name: replace-nodes
           restartPolicy: Never
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: remove-nodes-upgrade-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: appuio-openshift-upgrade-controller
+          serviceAccountName: hook-manager
 ----
 
 == Manually rotate the service CA certificate
@@ -135,7 +109,6 @@ Force a rotation of the service CA certificate during the maintenance.
 See the https://docs.openshift.com/container-platform/4.15/security/certificates/service-serving-certificate.html#manually-rotate-service-ca_service-serving-certificate[OpenShift documentation] for details.
 The rotation will be skipped for noop upgradejobs.
 Only runs once on the next UpgradeJob due to the `.spec.run: Next` setting.
-A clusterrolebinding for cluster-admin for the appuio-openshift-upgrade-controller default serviceaccount is included below.
 
 [source,yaml]
 ----
@@ -182,20 +155,8 @@ spec:
                   name: export
               workingDir: /export
           restartPolicy: Never
+          serviceAccountName: hook-manager
           volumes:
             - emptyDir: {}
               name: export
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: rotate-service-ca-cert
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: appuio-openshift-upgrade-controller
 ----

--- a/docs/modules/ROOT/pages/how-tos/upgradejobhooks.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgradejobhooks.adoc
@@ -50,11 +50,13 @@ spec:
                   name: export
               workingDir: /export
           restartPolicy: Never
-          serviceAccountName: hook-manager
+          serviceAccountName: hook-manager <1>
           volumes:
             - emptyDir: {}
               name: export
 ----
+<1> When deploying the hook through the component parameter `upgrade_job_hooks`, the `serviceAccountName` field can be omitted.
+The component injects `serviceAccountName: hook-manager` for hooks deployed via component parameter `upgrade_job_hooks`.
 
 
 == Replace nodes during maintenance
@@ -100,8 +102,10 @@ spec:
               image: quay.io/appuio/oc:v4.20
               name: replace-nodes
           restartPolicy: Never
-          serviceAccountName: hook-manager
+          serviceAccountName: hook-manager <1>
 ----
+<1> When deploying the hook through the component parameter `upgrade_job_hooks`, the `serviceAccountName` field can be omitted.
+The component injects `serviceAccountName: hook-manager` for hooks deployed via component parameter `upgrade_job_hooks`.
 
 == Manually rotate the service CA certificate
 
@@ -155,8 +159,10 @@ spec:
                   name: export
               workingDir: /export
           restartPolicy: Never
-          serviceAccountName: hook-manager
+          serviceAccountName: hook-manager <1>
           volumes:
             - emptyDir: {}
               name: export
 ----
+<1> When deploying the hook through the component parameter `upgrade_job_hooks`, the `serviceAccountName` field can be omitted.
+The component injects `serviceAccountName: hook-manager` for hooks deployed via component parameter `upgrade_job_hooks`.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -134,6 +134,12 @@ See https://github.com/appuio/openshift-upgrade-controller for the manifest defi
 [TIP]
 `spec.selector` can be referenced from the `UpgradeConfig` object using Commodore variable expansion.
 
+[TIP]
+====
+The component deploys a service account named `hook-manager` which is granted `cluster-admin`.
+This service account is set as `spec.template.spec.template.serviceAccountName` in each hook defined through this parameter.
+User-provided values for `spec.template.spec.template.serviceAccountName` take precedence over this default.
+====
 
 == upgrade_suspension_windows
 

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: hook-manager
+  name: hook-manager
+  namespace: appuio-openshift-upgrade-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: openshift-upgrade-controller-hook-manager-cluster-admin
+  name: openshift-upgrade-controller:hook-manager:cluster-admin
+roleRef:
+  apiVersion: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: hook-manager
+    namespace: appuio-openshift-upgrade-controller

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/22_upgradejobhooks.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/22_upgradejobhooks.yaml
@@ -36,4 +36,5 @@ spec:
               name: notify
           priorityClassName: system-cluster-critical
           restartPolicy: Never
+          serviceAccountName: hook-manager
       ttlSecondsAfterFinished: 43200

--- a/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
+++ b/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: hook-manager
+  name: hook-manager
+  namespace: appuio-openshift-upgrade-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    name: openshift-upgrade-controller-hook-manager-cluster-admin
+  name: openshift-upgrade-controller:hook-manager:cluster-admin
+roleRef:
+  apiVersion: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: hook-manager
+    namespace: appuio-openshift-upgrade-controller


### PR DESCRIPTION
Until now each user that defined upgradejobhooks via component parameter needed to manually define RBAC for their hook. This commit deploys a dedicated service account which is granted `cluster-admin`. This service account is configured in each hook that's defined through the component parameter. Users can override the service account by setting `spec.template.spec.template.serviceAccountName` in their upgradejobhook definition.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
