### PR TITLE
Inject default values for `UpgradeJobHooks`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,6 +26,16 @@ parameters:
 
     upgrade_configs: {}
 
+    upgrade_job_hook_defaults:
+      spec:
+        template:
+          spec:
+            activeDeadlineSeconds: 900 # 15 minutes
+            template:
+              spec:
+                restartPolicy: Never
+                priorityClassName: system-cluster-critical
+
     upgrade_job_hooks: {}
 
     upgrade_suspension_windows: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -61,7 +61,7 @@ local upgradeJobHookCRB =
 
 local upgradeJobHooks = com.generateResources(
   params.upgrade_job_hooks,
-  function(name) kube._Object(api.apiVersion, 'UpgradeJobHook', name) {
+  function(name) kube._Object(api.apiVersion, 'UpgradeJobHook', name) + com.makeMergeable(params.upgrade_job_hook_defaults) {
     metadata+: {
       namespace: params.namespace,
     },
@@ -71,7 +71,6 @@ local upgradeJobHooks = com.generateResources(
           template+: {
             spec+: {
               serviceAccountName: upgradeJobHookSA.metadata.name,
-              priorityClassName: 'system-cluster-critical',
             },
           },
         },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -79,6 +79,30 @@ The value is the configuration of the `UpgradeConfig` object.
 
 See https://github.com/appuio/openshift-upgrade-controller for the manifest definition.
 
+== upgrade_job_hook_defaults [[upgrade_job_hook_defaults]]
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+upgrade_job_hook_defaults:
+  spec:
+    template:
+      spec:
+        activeDeadlineSeconds: 900 # 15 minutes <1>
+        template:
+          spec:
+            restartPolicy: Never
+            priorityClassName: system-cluster-critical <2>
+----
+<1> Ensures that hooks don't run until the global timeout in case of misconfiguration or issues with the hook job.
+<2> Ensures that hooks are prioritized by the scheduler.
+
+Default values for all `UpgradeJobHook` objects created through the `upgrade_job_hooks` parameter.
+
+Those values can be overridden by setting the corresponding fields in the `upgrade_job_hooks` parameter.
 
 == upgrade_job_hooks
 
@@ -127,7 +151,8 @@ This parameter is used to configure the `UpgradeJobHooks` objects.
 The dictionary key is used as the name of the `UpgradeJobHooks` object.
 The value is the configuration of the `UpgradeJobHooks` object.
 
-`UpgradeJobHooks` default to `priorityClassName: system-cluster-critical`.
+[TIP]
+See the default values in <<upgrade_job_hook_defaults>>.
 
 See https://github.com/appuio/openshift-upgrade-controller for the manifest definition.
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -35,6 +35,22 @@ parameters:
                   timeout: 1h
 
     upgrade_job_hooks:
+      mitigate:
+        spec:
+          events:
+            - Start
+          selector:
+            matchLabels: ${openshift_upgrade_controller:upgrade_configs:appuio-monday-afternoon:spec:jobTemplate:metadata:labels}
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: mitigate
+                      image: quay.io/appuio/upgrade-mitigate:latest
+                      args: [check]
+                  restartPolicy: Never
+
       notify:
         spec:
           events:

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/22_upgradejobhooks.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/22_upgradejobhooks.yaml
@@ -2,6 +2,33 @@ apiVersion: managedupgrade.appuio.io/v1beta1
 kind: UpgradeJobHook
 metadata:
   labels:
+    name: mitigate
+  name: mitigate
+  namespace: appuio-openshift-upgrade-controller
+spec:
+  events:
+    - Start
+  selector:
+    matchLabels:
+      upgradeconfig/name: appuio-monday-afternoon
+  template:
+    spec:
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          containers:
+            - args:
+                - check
+              image: quay.io/appuio/upgrade-mitigate:latest
+              name: mitigate
+          priorityClassName: system-cluster-critical
+          restartPolicy: Never
+          serviceAccountName: hook-manager
+---
+apiVersion: managedupgrade.appuio.io/v1beta1
+kind: UpgradeJobHook
+metadata:
+  labels:
     name: notify
   name: notify
   namespace: appuio-openshift-upgrade-controller


### PR DESCRIPTION
Adds `activeDeadlineSeconds` to expire hook jobs before global maintenance timeouts. Adds `restartPolicy` as it's commonly forgotten and causes the job to fail to apply.

Superseeds #105 .

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
