### PR TITLE
Set higher activeDeadlineSeconds for long running hook example

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/upgradejobhooks.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgradejobhooks.adoc
@@ -103,9 +103,11 @@ spec:
               name: replace-nodes
           restartPolicy: Never
           serviceAccountName: hook-manager <1>
+          activeDeadlineSeconds: 3600 <2>
 ----
 <1> When deploying the hook through the component parameter `upgrade_job_hooks`, the `serviceAccountName` field can be omitted.
 The component injects `serviceAccountName: hook-manager` for hooks deployed via component parameter `upgrade_job_hooks`.
+<2> Set a higher value to ensure job can finish if you replace many nodes.
 
 == Manually rotate the service CA certificate
 


### PR DESCRIPTION
We now inject 900 (15min) by default if not set.

Follow up of #106.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
