### PR TITLE
Fix ClusterRoleBinding for UpgradeJobHook service account

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -52,7 +52,7 @@ local upgradeJobHookCRB =
   kube.ClusterRoleBinding('openshift-upgrade-controller:hook-manager:cluster-admin')
   {
     roleRef: {
-      apiVersion: 'rbac.authorization.k8s.io',
+      apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
       name: 'cluster-admin',
     },

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     name: openshift-upgrade-controller-hook-manager-cluster-admin
   name: openshift-upgrade-controller:hook-manager:cluster-admin
 roleRef:
-  apiVersion: rbac.authorization.k8s.io
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:

--- a/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
+++ b/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/15_upgradejobhook_rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     name: openshift-upgrade-controller-hook-manager-cluster-admin
   name: openshift-upgrade-controller:hook-manager:cluster-admin
 roleRef:
-  apiVersion: rbac.authorization.k8s.io
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:


### PR DESCRIPTION
It's `roleRef.apiGroup` not `roleRef.apiVersion`...

Fixes #104 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
