### PR TITLE
Add pod annotation `openshift.io/required-scc=restricted-v2` to the upgrade job hook template

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -32,6 +32,13 @@ parameters:
           spec:
             activeDeadlineSeconds: 900 # 15 minutes
             template:
+              metadata:
+                annotations:
+                  # Ensure upgradejobhook pods run with SCC restricted-v2 by
+                  # default to avoid unpleasant surprises since the default
+                  # hook-manager SA now has system:admin and can use arbitrary
+                  # SCCs.
+                  openshift.io/required-scc: restricted-v2
               spec:
                 restartPolicy: Never
                 priorityClassName: system-cluster-critical

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -93,12 +93,18 @@ upgrade_job_hook_defaults:
       spec:
         activeDeadlineSeconds: 900 # 15 minutes <1>
         template:
+          metadata:
+            annotations:
+              openshift.io/required-scc: restricted-v2 <2>
           spec:
             restartPolicy: Never
-            priorityClassName: system-cluster-critical <2>
+            priorityClassName: system-cluster-critical <3>
 ----
 <1> Ensures that hooks don't run until the global timeout in case of misconfiguration or issues with the hook job.
-<2> Ensures that hooks are prioritized by the scheduler.
+<2> Ensures that hooks run with SCC `restricted-v2` by default.
+With the recent addition of the `hook-manager` service account which is granted `cluster-admin`, there's a chance that jobs run with arbitrary other SCCs if we don't set this annotation.
+This annotation is also used by OpenShift itself, so it should be safe to rely on this working as intended.
+<3> Ensures that hooks are prioritized by the scheduler.
 
 Default values for all `UpgradeJobHook` objects created through the `upgrade_job_hooks` parameter.
 

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/22_upgradejobhooks.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/22_upgradejobhooks.yaml
@@ -15,6 +15,9 @@ spec:
     spec:
       activeDeadlineSeconds: 900
       template:
+        metadata:
+          annotations:
+            openshift.io/required-scc: restricted-v2
         spec:
           containers:
             - args:
@@ -50,6 +53,9 @@ spec:
       activeDeadlineSeconds: 300
       backoffLimit: 3
       template:
+        metadata:
+          annotations:
+            openshift.io/required-scc: restricted-v2
         spec:
           containers:
             - args:


### PR DESCRIPTION
This ensures that all upgrade job hooks defined through the component run with SCC `restricted-v2` unless configured otherwise. This has become necessary because the new `hook-manager` service account is able to use any SCC that's present (because it's granted `cluster-admin`).

This can lead to issues where the assumption that commands run with an arbitrary high UID and GID and that configmaps are mounted with the same GID doesn't hold (note that this assumption is guaranteed by SCC `restricted-v2`).

A hook failure that we've observed is that a hook that runs with SCC `anyuid` because its container image requests `uid=1000`/`gid=1000`. However, this pod now runs into an error because it tries to run a script from a configmap that's mounted with `defaultMode=360` which results in the mounted files having `owner=root` and `group=root` with SCC `anyuid`.

Follow-up for #106


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
