### PR TITLE
Add option to exclude failed upgradejobs from alert after investigation

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -150,6 +150,8 @@ parameters:
             runbook_url: https://hub.syn.tools/openshift-upgrade-controller/runbooks/UpgradeJobFailed.html
           expr: |
             openshift_upgrade_controller_upgradejob_state{state="failed"}
+            unless on(upgradejob)
+            (label_replace(kube_configmap_info{namespace="appuio-openshift-upgrade-controller"}, "upgradejob", "$1", "configmap", "ack-(.*)"))
           for: 1m
           labels:
             severity: warning

--- a/docs/modules/ROOT/pages/runbooks/UpgradeJobFailed.adoc
+++ b/docs/modules/ROOT/pages/runbooks/UpgradeJobFailed.adoc
@@ -9,7 +9,7 @@ This alert fires when a upgrade job has failed.
 Machine config pools might still try to apply changes if not paused.
 If the automatic pause on fail is enabled the next maintenance might be blocked.
 
-To clear this alert delete the failed UpgradeJob after investigating the root cause.
+Afer investigation, a failed upgradejob can be excluded from the alert query by creating a configmap with a `ack-` prefix and the name of the upgradejob (see below).
 
 [WARNING]
 ====
@@ -72,6 +72,28 @@ To unpause a Machine Config Pool:
 ----
 POOL=XXX
 kubectl --as=system:admin patch mcp $POOL -p '{"spec":{"paused":false}}' --type=merge
+----
+
+== icon:wrench[] Clear the alert
+
+Afer investigation, a failed upgradejob can be excluded from the alert query by creating a configmap with a `ack-` prefix and the name of the upgradejob.
+Ideally add a short comment explain the root cause for the failure.
+
+[source,shell]
+----
+COMMENT="fixed"
+LATEST_FAILED_JOB=$(
+    kubectl -n appuio-openshift-upgrade-controller get upgradejob \
+    --sort-by .metadata.creationTimestamp -oyaml |\
+    yq '.items[] | select(.status.conditions[].type | contains("Failed")) | .metadata.name' |\
+    tail -n1
+)
+if [[ -n $LATEST_FAILED_JOB ]]; then
+    kubectl --as system:admin -n appuio-openshift-upgrade-controller create configmap\
+    ack-$LATEST_FAILED_JOB --from-literal comment=$COMMENT
+else
+    echo "No failed job found"
+fi
 ----
 
 == icon:wrench[] Tune

--- a/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
+++ b/tests/golden/defaults/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
@@ -64,6 +64,8 @@ spec:
             summary: Failed UpgradeJob
           expr: |
             openshift_upgrade_controller_upgradejob_state{state="failed"}
+            unless on(upgradejob)
+            (label_replace(kube_configmap_info{namespace="appuio-openshift-upgrade-controller"}, "upgradejob", "$1", "configmap", "ack-(.*)"))
           for: 1m
           labels:
             severity: warning

--- a/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
+++ b/tests/golden/delayed-pool-silence/openshift-upgrade-controller/openshift-upgrade-controller/10_prometheusrule.yaml
@@ -64,6 +64,8 @@ spec:
             summary: Failed UpgradeJob
           expr: |
             openshift_upgrade_controller_upgradejob_state{state="failed"}
+            unless on(upgradejob)
+            (label_replace(kube_configmap_info{namespace="appuio-openshift-upgrade-controller"}, "upgradejob", "$1", "configmap", "ack-(.*)"))
           for: 1m
           labels:
             severity: warning


### PR DESCRIPTION
Afer investigation, a failed upgradejob can be excluded from the alert query by creating a configmap with a `ack-` prefix and the name of the upgradejob.

This allows to keep failed upgradejobs in the "history" and helps troubleshooting future failures. Copy-pasting the commands from the runbook to clear the alert is also less tedious than deleting the upgradejob and all it's owned resources that can block the deletion.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
